### PR TITLE
Fix Missing Nox Interpreters

### DIFF
--- a/.github/workflows/code_hygiene.yml
+++ b/.github/workflows/code_hygiene.yml
@@ -23,7 +23,7 @@ jobs:
           echo "# Linting Issues" > linting_report.md
           echo "| Path | Row | Col | Code | Msg |" >> linting_report.md
           echo "| --- | --- | --- | --- |  --- |" >> linting_report.md
-          nox --sessions lint >> linting_report.md
+          nox --sessions lint --no-error-on-missing-interpreters >> linting_report.md
           sed -i -e 's/$/    /' linting_report.md
       - name: Save Linting Report
         if: ${{ failure() }}

--- a/.github/workflows/code_hygiene.yml
+++ b/.github/workflows/code_hygiene.yml
@@ -49,7 +49,7 @@ jobs:
           pip install poetry
           pip install nox-poetry
       - name: Run Type Checking
-        run: nox --sessions mypy
+        run: nox --sessions mypy --no-error-on-missing-interpreters
       - name: Save MyPy Report
         if: ${{ failure() }}
         uses: machine-learning-apps/pr-comment@master
@@ -74,7 +74,7 @@ jobs:
           pip install poetry
           pip install nox-poetry
       - name: Generate Coverage Report
-        run: nox --sessions tests coverage
+        run: nox --sessions tests coverage --no-error-on-missing-interpreters
         env:
           CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
 
@@ -94,4 +94,4 @@ jobs:
           pip install poetry
           pip install nox-poetry
       - name: Run Safety
-        run: nox --sessions safety
+        run: nox --sessions safety --no-error-on-missing-interpreters

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,6 +7,8 @@ from nox_poetry import Session, session
 
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
 
+# Required as GH Actions runs on a matrix of python environments & thus only one
+# interpretter will be available each run
 nox.options.error_on_missing_interpreters = False
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,14 +2,9 @@
 
 import tempfile
 
-import nox
 from nox_poetry import Session, session
 
 PYTHON_VERSIONS = ["3.8", "3.9", "3.10"]
-
-# Required as GH Actions runs on a matrix of python environments & thus only one
-# interpretter will be available each run
-nox.options.error_on_missing_interpreters = False
 
 
 @session(python=PYTHON_VERSIONS)


### PR DESCRIPTION
## Description of the Change

Closes #16 
Stop nox from failing due to missing interpreters, which is due to running on a matrix of python environments. 

## Change Hygiene

Please ensure the following items are complete for all PR's:

- [ ] All CI (`nox`) is passing
- [ ] Documentation appropriately updated
- [ ] Version updated in `pyproject.toml`
